### PR TITLE
Updates for controller v7.1 compatibility

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
   backend "remote" {
     hostname = "app.terraform.io"
     # organization = "<replace-with-your-Terraform-Cloud-organization-and-uncomment>"

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aviatrix_account" "azure_account" {
 # AWS Transit Modules
 module "aws_transit_1" {
   source              = "terraform-aviatrix-modules/mc-transit/aviatrix"
-  version             = "2.4.1"
+  version             = "2.5.0"
   cloud               = "AWS"
   account             = var.aws_account_name
   region              = var.aws_transit1_region
@@ -39,7 +39,7 @@ module "aws_transit_1" {
 # AWS Spoke Modules
 module "aws_spoke_1" {
   source          = "terraform-aviatrix-modules/mc-spoke/aviatrix"
-  version         = "1.5.0"
+  version         = "1.6.1"
   cloud           = "AWS"
   account         = var.aws_account_name
   region          = var.aws_spoke1_region
@@ -53,7 +53,7 @@ module "aws_spoke_1" {
 
 module "azure_spoke_2" {
   source          = "terraform-aviatrix-modules/mc-spoke/aviatrix"
-  version         = "1.5.0"
+  version         = "1.6.1"
   cloud           = "Azure"
   account         = aviatrix_account.azure_account.account_name
   region          = var.azure_spoke2_region

--- a/versions.tf
+++ b/versions.tf
@@ -2,16 +2,16 @@ terraform {
   required_providers {
     aviatrix = {
       source  = "AviatrixSystems/aviatrix"
-      version = "~> 3.0.1"
+      version = "~> 3.1.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0.0"
+      version = "~> 3.58"
     }
   }
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 }


### PR DESCRIPTION
Update for controller v7.1 compatibility. Also require terraform >= 1.2 as the transit/spoke modules impose this requirement